### PR TITLE
Enabling Cloud Manager API is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ It is a good practice to do a dry run of Terraform prior to running it:
 $ terraform plan
 ```
 
-`plan` will prompt for any variables that do not have defaults and will output all the changes that Terraform will perform when applied. If everything looks good then it is time to put Terraform to work assembling your cloud infrastructure:
+`plan` will prompt for any variables that do not have defaults and will output all the changes that Terraform will perform when applied. 
+
+*Note*: If this is a new project, you'll likely need to enable the [Cloud Resource Manager API](https://console.cloud.google.com/apis/api/cloudresourcemanager.googleapis.com/overview). Otherwise, running Terraform will result in an error.
+
+If everything looks good then it is time to put Terraform to work assembling your cloud infrastructure:
 
 ```console
 $ terraform apply


### PR DESCRIPTION
Running `terraform apply` without this API enabled in your project results in several errors:

```
* google_project_service.monitoring: 1 error(s) occurred:

* google_project_service.monitoring: Error reading mmatthias-gke-experiments: googleapi: Error 403: Cloud Resource Manager API has not been used in project 338122545156 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview?project=338122545156 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* google_project_service.container: 1 error(s) occurred:

* google_project_service.container: Error reading mmatthias-gke-experiments: googleapi: Error 403: Cloud Resource Manager API has not been used in project 338122545156 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview?project=338122545156 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* google_project_service.logging: 1 error(s) occurred:

* google_project_service.logging: Error reading mmatthias-gke-experiments: googleapi: Error 403: Cloud Resource Manager API has not been used in project 338122545156 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview?project=338122545156 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
```