### PR TITLE
Add prometheus sed file & enable apis

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -31,15 +31,6 @@ source "$ROOT/scripts/common.sh"
 # shellcheck source=scripts/generate-tfvars.sh
 "$ROOT/scripts/generate-tfvars.sh"
 
-# sed the prometheus file for the project specific stuff
-PROJECT=$(gcloud config get-value core/project)
-CLUSTER_NAME="stackdriver-monitoring-tutorial"
-ZONE=$(gcloud config get-value compute/zone)
-sed -e "s/\\[PROJECT_ID\\]/$PROJECT/" \
--e "s/\\[CLUSTER_NAME\\]/$CLUSTER_NAME/" \
--e "s/\\[CLUSTER_ZONE\\]/$ZONE/" "$ROOT/manifests/prometheus-service.yaml" \
-> "$ROOT/manifests/prometheus-service-sed.yaml"
-
 # Initialize and run Terraform
 (cd "$ROOT/terraform"; terraform init -input=false)
 (cd "$ROOT/terraform"; terraform apply -input=false -auto-approve)

--- a/scripts/generate-tfvars.sh
+++ b/scripts/generate-tfvars.sh
@@ -61,3 +61,9 @@ project="${PROJECT}"
 zone="${ZONE}"
 EOF
 
+# Generate the prometheus yaml that `terraform apply` requires
+CLUSTER_NAME="stackdriver-monitoring-tutorial"
+sed -e "s/\\[PROJECT_ID\\]/$PROJECT/" \
+    -e "s/\\[CLUSTER_NAME\\]/$CLUSTER_NAME/" \
+    -e "s/\\[CLUSTER_ZONE\\]/$ZONE/" "$ROOT/manifests/prometheus-service.yaml" \
+    > "$ROOT/manifests/prometheus-service-sed.yaml"

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -59,6 +59,10 @@ resource "google_container_cluster" "primary" {
   }
 
   provisioner "local-exec" {
+    command = "gcloud services enable compute.googleapis.com container.googleapis.com cloudbuild.googleapis.com cloudresourcemanager.googleapis.com"
+  }
+
+  provisioner "local-exec" {
     command = "gcloud container clusters get-credentials ${google_container_cluster.primary.name} --zone ${google_container_cluster.primary.zone} --project ${var.project}"
   }
 


### PR DESCRIPTION
I followed the instructions in the README to run these commands from a clean clone:

```
./scripts/generate-tfvars.sh
terraform init
terraform plan
terraform apply
```

and ran into 2 problems:

1. The Makefile generates the prometheus sed file via `scripts/create.sh`, but the `generate-tfvars.sh` script doesn't, which is the script that the README instructs people to use. So the README either needs to be updated to use make or the `scripts/create.sh` script (which would defeat the opportunity to use terraform directly), or the prometheus sed file needs to be generated as part of the instructions to use the `generate-tfvars.sh` script. Instead of making a new script and adding the instruction to the README to run the script all on its own, I simply moved the `sed` command to the `generate-tfvars.sh` script so that it would be called when using make and when following the instructions to generate the terraform variables file.

2. On my very first run of this (first new project in a new GCP account), I got an error that the Cloud Resource Manager API needed enabling. I added a `local-exec` command to the terraform resource file so that any APIs we might need enabled are ensured to be enabled.
