### PR TITLE
Enable any APIs we might need when creating cluster

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -40,6 +40,12 @@ sed -e "s/\\[PROJECT_ID\\]/$PROJECT/" \
 -e "s/\\[CLUSTER_ZONE\\]/$ZONE/" "$ROOT/manifests/prometheus-service.yaml" \
 > "$ROOT/manifests/prometheus-service-sed.yaml"
 
+# Enable any APIs we need
+gcloud services enable compute.googleapis.com \
+    container.googleapis.com \
+    cloudbuild.googleapis.com \
+    cloudresourcemanager.googleapis.com
+
 # Initialize and run Terraform
 (cd "$ROOT/terraform"; terraform init -input=false)
 (cd "$ROOT/terraform"; terraform apply -input=false -auto-approve)


### PR DESCRIPTION
On my very first run of this (first new project in a new GCP account), I got an error that the Cloud Resource Manager API needed enabling.

This commit enables those APIs in the creation script before doing any terraform commands.