### PR TITLE
Rollback to 0.4.1

### DIFF
--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -50,7 +50,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: gcr.io/stackdriver-prometheus/stackdriver-prometheus:release-0.4.3
+        image: gcr.io/stackdriver-prometheus/stackdriver-prometheus:release-0.4.1
         # Uncomment this to enable debug logs. Can be very verbose.
         #args: ["--config.file=/etc/prometheus/prometheus.yml", "--log.level=debug"]
         # Helps during development, when reusing the tag.

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -82,7 +82,7 @@ resource "google_monitoring_alert_policy" "prometheus_mem_alloc" {
   conditions = [{
     display_name = "mem alloc above 12"
     condition_threshold = {
-      filter = "metric.type=\"external.googleapis.com/prometheus/go_memstats_alloc_bytes\" AND resource.type=\"k8s_container\""
+      filter = "metric.type=\"custom.googleapis.com/go_memstats_alloc_bytes\" AND resource.type=\"k8s_container\""
       duration = "60s"
       comparison = "COMPARISON_GT"
       threshold_value = 12


### PR DESCRIPTION
Resolved the error - The metric referenced by the provided filter is unknown.