### PR TITLE
Migrate prometheus Deployment's apiVersion

### DIFF
--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -30,7 +30,7 @@ spec:
 ---
 apiVersion: v1
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: prometheus
 spec:


### PR DESCRIPTION
Since existing apiVersion `extensions/v1beta1` was deprecated replace it with `apps/v1` .