### PR TITLE
Fix rbac api version

### DIFF
--- a/manifests/rbac-setup.yaml
+++ b/manifests/rbac-setup.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -38,7 +38,7 @@ kind: ServiceAccount
 metadata:
   name: prometheus
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-stackdriver


### PR DESCRIPTION
Fixed Issue #42 

rbac.authorization.k8s.io/v1beta1 is no longer served as of v.1.22.